### PR TITLE
Add master build tracker and workstream task boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# AWS Inspector Operations Platform Planning Repo
+
+This repository houses the coordinated build plan for the AWS Inspector operations platform. It captures the implementation strategy, workstream trackers, and operational guidance required to deliver the end-to-end system across presentation, ingestion, storage, processing, admin, security, and deployment domains.
+
+## Repository Structure
+| Path | Description |
+| --- | --- |
+| `stack-plan.md` | Approved high-level stack implementation plan captured during initial planning. |
+| `system-rebuild-guide.md` | Source guidance document informing requirements (read-only reference). |
+| `docs/master-build-tracker.md` | Master program management tracker for orchestrating all workstreams. |
+| `docs/subtasks/` | Individual workstream trackers with task boards, milestones, and update logs. |
+
+Future artefacts such as runbooks, research, and architecture diagrams should be stored in the suggested subdirectories referenced throughout the trackers (e.g., `docs/runbooks/`, `docs/architecture/`, `docs/research/`). Create directories as needed when contributing.
+
+## How to Use the Trackers
+1. **Start with the master tracker:** Review `docs/master-build-tracker.md` to understand overall status, owners, and cross-workstream dependencies.
+2. **Claim work:** Update the relevant `Primary Owner` field in the master tracker and the `Owner` field in the corresponding subtask file.
+3. **Maintain status fidelity:** After each working session, update status columns and the `Last Update` field in the master tracker and append a dated entry to the subtask’s Update Log summarizing progress, blockers, and next steps.
+4. **Link artefacts:** When producing designs, diagrams, or runbooks, store them in the repo (or link to external tools) and reference them in the Notes/Links column of the relevant task.
+5. **Escalate blockers:** Use the Risk & Issue Log in the master tracker to highlight cross-cutting concerns. Escalations should also appear in the subtask Notes field with mitigation steps.
+
+## Status Vocabulary
+All trackers share the same status vocabulary to simplify orchestration:
+- **Not Started** — Work item has not begun; available for pickup.
+- **In Progress** — Work is actively underway.
+- **Blocked** — Progress halted pending dependency resolution.
+- **Error** — Execution failed; remediation required before proceeding.
+- **Complete** — Acceptance criteria met and validated.
+
+## Contribution Workflow
+- **Editing:** Update markdown files directly and ensure tables remain valid. Maintain chronological order in Update Logs.
+- **Decision Logging:** Record significant architectural or product decisions in the relevant Notes sections and, if cross-cutting, in the Program Operations risk log.
+- **Runbooks & Documentation:** Store operational documents under `docs/runbooks/` and link them from the workstream trackers.
+- **Change Management:** Any scope or requirement changes must be logged in the master tracker’s Change Management section and propagated to affected subtask documents.
+
+## Onboarding Checklist for New Contributors
+- Read `system-rebuild-guide.md` to absorb context.
+- Review `stack-plan.md` for the agreed architectural direction.
+- Study `docs/master-build-tracker.md` for current priorities and ownership.
+- Select a subtask file, review its mission and milestones, and update the `Owner` field when claiming work.
+- Confirm security and compliance requirements with the Security workstream before handling sensitive data or integrations.
+
+## Communication Expectations
+- Daily async updates should be captured via tracker edits; no separate standup doc is required unless noted.
+- Weekly stakeholder summaries should aggregate workstream highlights and be archived under `docs/reports/` once created.
+- Major decisions or escalations must be highlighted in both the master tracker and relevant subtask Notes sections for traceability.
+
+## Questions & Clarifications
+Outstanding clarifications (e.g., tech stack preferences, authentication scope, export priorities, backup cadence, ingest volume) are tracked under Program Operations in the master tracker. When answers are obtained, update both the master tracker and any affected subtasks.
+

--- a/docs/master-build-tracker.md
+++ b/docs/master-build-tracker.md
@@ -1,0 +1,71 @@
+# AWS Inspector Ops Platform — Master Build Tracker
+
+This master tracker translates the approved stack implementation plan into an executable program of work. It is designed for orchestration agents to coordinate specialist contributors across the full build lifecycle while maintaining clear visibility into status, ownership, and dependencies.
+
+## Status Legend
+- **Not Started** — No active work yet; ready for pickup.
+- **In Progress** — Work has begun but is not yet complete.
+- **Blocked** — Work is paused pending resolution of a dependency or issue.
+- **Error** — Work encountered a failure that requires remediation or escalation.
+- **Complete** — Work has met the acceptance criteria and is ready for QA/next stage.
+
+## Workstream Overview
+| Workstream | Scope Summary | Primary Owner | Current Status | Last Update |
+| --- | --- | --- | --- | --- |
+| [Program Operations](#program-operations) | Cross-cutting PMO duties, clarifications, decision tracking, and release readiness. | Unassigned | Not Started | _None_ |
+| [Presentation Layer](subtasks/presentation-layer.md) | Web UI, accessibility, workflow UX, and public API surface. | Unassigned | Not Started | _None_ |
+| [Ingestion Pipeline](subtasks/ingestion-pipeline.md) | Upload intake, staging, normalization, and processing orchestration. | Unassigned | Not Started | _None_ |
+| [Data Storage & Modeling](subtasks/data-storage-modeling.md) | Relational schema design, migrations, indexing, and provenance rules. | Unassigned | Not Started | _None_ |
+| [Background Processing & Exports](subtasks/background-processing-exports.md) | Async job platform, export generation, archival workflows, telemetry. | Unassigned | Not Started | _None_ |
+| [Admin & Telemetry Surfaces](subtasks/admin-telemetry.md) | Admin console, health probes, monitoring, and audit logging. | Unassigned | Not Started | _None_ |
+| [Security & Compliance](subtasks/security-compliance.md) | Secure handling of uploads, secrets management, auth strategy, and governance. | Unassigned | Not Started | _None_ |
+| [Deployment & Operations](subtasks/deployment-operations.md) | Docker delivery, environment configuration, scaling, backups, DR, and release validation. | Unassigned | Not Started | _None_ |
+
+> **Update protocol:** Orchestration agents must update the table after each working session by editing the `Current Status` and `Last Update` columns and linking to the relevant progress notes in the associated subtask file.
+
+## Program Operations
+**Objectives**
+- Centralize decision logs, clarifications, and cross-workstream risks.
+- Ensure clarifying questions from the stack plan are resolved and recorded.
+- Coordinate timelines, release readiness reviews, and stakeholder communications.
+
+**Key Tasks**
+| Task | Owner | Dependencies | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Capture responses to outstanding clarifying questions (tech stack, auth scope, export priorities, backup cadence, ingest volume). | Unassigned | Stakeholder input | Not Started | Document answers in this section and relevant subtask(s). |
+| Establish intake process for new requirements, scope changes, and risk escalations. | Unassigned | None | Not Started | Define SLA for responses and update README if process changes. |
+| Maintain master delivery timeline and sprint/iteration plan. | Unassigned | All workstreams | Not Started | Create `docs/schedule.md` if timeline detail exceeds this tracker. |
+| Publish weekly stakeholder status summaries referencing each workstream. | Unassigned | Workstream updates | Not Started | Archive summaries in `/docs/reports/` if generated. |
+
+**Communication Cadence**
+- Daily async update posted via tracker edits.
+- Twice-weekly standup (or written equivalent) summarizing blockers.
+- Release readiness review at end of each major milestone.
+
+## Dependencies & Coordination
+- **Shared Environments:** Data modeling, ingestion, and background processing must align on schema versioning—coordinate migrations via change control documented in the Data Storage subtask.
+- **API Contracts:** Presentation Layer and Admin tooling depend on API endpoints specified by Ingestion and Background Processing—ensure OpenAPI/GraphQL schemas are versioned and reviewed before implementation.
+- **Security Sign-off:** No deployment workstream tasks may reach _Complete_ status without Security & Compliance review notes recorded in both trackers.
+
+## Risk & Issue Log
+| Risk/Issue | Impact | Owner | Mitigation/Next Steps | Status |
+| --- | --- | --- | --- | --- |
+| Pending stakeholder decisions on authentication, export priority, backup cadence, and ingest volume sizing. | Medium | Program Operations | Follow up with stakeholders; record decisions once received. | Not Started |
+
+## Deliverable Acceptance Checklist
+- [ ] All workstream subtasks show **Complete** status with supporting QA evidence or links to verification artefacts.
+- [ ] README reflects final deployment/operational guidance and any deviations from this plan.
+- [ ] Security & Compliance sign-off documented for ingestion, storage, admin, and deployment workstreams.
+- [ ] Release notes drafted and approved by stakeholders.
+
+## Change Management
+Any adjustments to scope, timelines, or acceptance criteria must be:
+1. Logged under **Risk & Issue Log** with new status.
+2. Communicated to affected workstream leads via their subtask documents.
+3. Reflected in the **Workstream Overview** table and, if necessary, the README.
+
+## Artifacts & Links
+- [Stack Implementation Plan](../stack-plan.md)
+- [System Rebuild Guide](../system-rebuild-guide.md)
+- Subtask trackers under `docs/subtasks/`
+

--- a/docs/subtasks/admin-telemetry.md
+++ b/docs/subtasks/admin-telemetry.md
@@ -1,0 +1,46 @@
+# Workstream Tracker — Admin & Telemetry Surfaces
+
+## Mission
+Deliver administrative consoles, health endpoints, monitoring dashboards, and audit logging that give operators visibility and control over the platform’s ingestion, processing, and export workflows.
+
+## Current Status
+- **Owner:** Unassigned
+- **Status:** Not Started
+- **Last Update:** _None_
+
+## Milestones & Target Outcomes
+| Milestone | Description | Target Exit Criteria | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Requirements & IA Design | Define admin personas, information architecture, and access controls. | Approved IA diagrams and access model documented. | Not Started | Coordinate with Security on RBAC. |
+| Health & Telemetry Endpoints | Implement liveness/readiness probes, system metrics APIs, and ingestion telemetry feeds. | Endpoints documented and monitored; automated tests created. | Not Started | Align with Deployment for probe specs. |
+| Admin Console Build | Create UI for backups, job monitoring, feature toggles, and audit trails. | Console integrated with auth; core tools functional. | Not Started | Shared components with Presentation UI. |
+| Audit & Logging | Define and implement audit log capture, storage, and review workflows. | Audit retention policy approved; query tools in place. | Not Started | Connect with Data Storage for retention. |
+| Verification & Handoff | Validate admin flows, publish runbooks, and train operators. | Sign-off recorded; documentation linked. | Not Started | Include escalation paths. |
+
+## Task Board
+| Task | Owner | Dependencies | Status | Notes/Links |
+| --- | --- | --- | --- | --- |
+| Identify admin user roles, permissions, and least-privilege requirements. | Unassigned | Security policy | Not Started | Document RBAC matrix. |
+| Specify metrics to expose (queue depth, ingest latency, export runtimes, error counts). | Unassigned | Other workstreams telemetry | Not Started | Sync with Background Processing metrics. |
+| Implement health endpoints compatible with container orchestrators. | Unassigned | Deployment probe requirements | Not Started | Add acceptance tests. |
+| Design admin dashboard UX, including job monitor, backup triggers, feature flag controls. | Unassigned | Presentation design system | Not Started | Share mockups. |
+| Integrate audit log viewing with filtering and export options. | Unassigned | Data Storage schema | Not Started | Ensure compliance requirements met. |
+| Build notification/alert hooks for critical failures surfaced in admin console. | Unassigned | Monitoring stack | Not Started | Document alert routing. |
+| Write operator runbooks covering backup, restore, and system health procedures. | Unassigned | Deployment & Security inputs | Not Started | Store in `/docs/runbooks/`. |
+
+## Dependencies
+- Metrics and logging from Ingestion, Background Processing, and Deployment.
+- Access control policies from Security & Compliance.
+- UI components from Presentation Layer.
+
+## Acceptance Criteria Checklist
+- [ ] Admin personas and permissions documented and approved.
+- [ ] Health probes and telemetry endpoints tested and monitored.
+- [ ] Admin console delivers required tools with audit logging.
+- [ ] Runbooks and alerting integrations finalized.
+- [ ] Compliance review completed and noted in Update Log.
+
+## Update Log
+| Date | Author | Summary |
+| --- | --- | --- |
+

--- a/docs/subtasks/background-processing-exports.md
+++ b/docs/subtasks/background-processing-exports.md
@@ -1,0 +1,48 @@
+# Workstream Tracker — Background Processing & Exports
+
+## Mission
+Build the asynchronous job system that powers archival workflows, export generation (PDF, CSV, Markdown/Notion), backups, and scheduled maintenance tasks while exposing progress telemetry for other surfaces.
+
+## Current Status
+- **Owner:** Unassigned
+- **Status:** Not Started
+- **Last Update:** _None_
+
+## Milestones & Target Outcomes
+| Milestone | Description | Target Exit Criteria | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Job Platform Selection | Evaluate and select queue/executor technology (e.g., Celery, RQ, Dramatiq). | Decision log published with scaling considerations. | Not Started | Coordinate with Deployment for container compatibility. |
+| Core Job Implementation | Implement archival moves, export generation jobs, retention enforcement, and backup triggers. | Jobs operational in local environment with test coverage. | Not Started | Ensure idempotency strategies documented. |
+| Export Delivery & API Integration | Provide async export request endpoints and download link generation. | API contract finalized; UI integration validated. | Not Started | Align with Presentation workstream. |
+| Monitoring & Telemetry | Expose job lifecycle metrics, alerting thresholds, and dashboards. | Metrics feeding Admin surfaces; alerts configured. | Not Started | Leverage shared observability stack. |
+| Runbooks & Handoff | Document operations guides, scaling procedures, and troubleshooting steps. | Runbooks stored in `/docs/runbooks/`; knowledge transfer complete. | Not Started | Include rollback instructions. |
+
+## Task Board
+| Task | Owner | Dependencies | Status | Notes/Links |
+| --- | --- | --- | --- | --- |
+| Gather requirements for export formats, destinations (Notion), and SLAs. | Unassigned | Stakeholder input | Not Started | Capture details from Program Ops. |
+| Compare job frameworks for Python backend (feature set, scaling, ops overhead). | Unassigned | Engineering constraints | Not Started | Summarize in decision matrix. |
+| Define archival workflow for moving snapshots to history tables and storage. | Unassigned | Data Storage schema | Not Started | Document safety checks. |
+| Implement export generators (CSV, PDF, Markdown, Notion API integration). | Unassigned | External service credentials | Not Started | Include rate limit handling. |
+| Create job orchestration for scheduled backups and retention policies. | Unassigned | Security compliance requirements | Not Started | Align with Deployment backup plan. |
+| Provide job status polling endpoints/webhooks for UI. | Unassigned | Presentation needs | Not Started | Document payload schema. |
+| Instrument metrics (queue depth, runtimes, failure rates). | Unassigned | Observability stack | Not Started | Feed into Admin dashboards. |
+| Establish alerting and retry strategies for job failures. | Unassigned | Monitoring tools | Not Started | Link to runbook entries. |
+| Write integration tests covering job orchestration and exports. | Unassigned | Test environment | Not Started | Record coverage results. |
+
+## Dependencies
+- Schema outputs from Data Storage.
+- Ingestion triggers for archival and export jobs.
+- Security policies for data handling and external integrations.
+
+## Acceptance Criteria Checklist
+- [ ] Job framework decision approved and documented.
+- [ ] All core jobs implemented with idempotent behavior and retries.
+- [ ] Export APIs deliver downloadable artifacts and Notion sync with audit logs.
+- [ ] Telemetry integrated with Admin dashboards and alerting configured.
+- [ ] Runbooks published with troubleshooting steps and escalation paths.
+
+## Update Log
+| Date | Author | Summary |
+| --- | --- | --- |
+

--- a/docs/subtasks/data-storage-modeling.md
+++ b/docs/subtasks/data-storage-modeling.md
@@ -1,0 +1,47 @@
+# Workstream Tracker — Data Storage & Modeling
+
+## Mission
+Design and implement the relational data model, migrations, indexing strategy, and provenance controls that underpin ingestion, analytics, and historical tracking for the AWS Inspector operations platform.
+
+## Current Status
+- **Owner:** Unassigned
+- **Status:** Not Started
+- **Last Update:** _None_
+
+## Milestones & Target Outcomes
+| Milestone | Description | Target Exit Criteria | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Conceptual Modeling | Define entities, relationships, and historical tracking approach. | ERD diagram, glossary, and decision log captured here. | Not Started | Include mapping to AWS Inspector fields. |
+| Schema & Migration Authoring | Build normalized schema, migrations, seed data, and indexing plans. | Migration scripts merged; index coverage validated. | Not Started | Align with ingestion staging requirements. |
+| Performance & Query Optimization | Benchmark key query patterns (filters, pagination, full-text search). | Performance metrics meet SLAs; indexes adjusted accordingly. | Not Started | Share results with Presentation workstream. |
+| Data Governance & Provenance | Implement append-only history tables, audit trails, retention rules. | Provenance documented; retention policies approved. | Not Started | Coordinate with Security on compliance requirements. |
+| Documentation & Handoff | Publish schema docs, ERDs, and change management process. | README updated; schema versioning workflow defined. | Not Started | Provide change request template. |
+
+## Task Board
+| Task | Owner | Dependencies | Status | Notes/Links |
+| --- | --- | --- | --- | --- |
+| Inventory required entities (reports, findings, resources, packages, references, uploads, history snapshots). | Unassigned | Stack plan, sample data | Not Started | Store ERD in `/docs/architecture/data-model/`. |
+| Decide on PostgreSQL extensions/features (UUIDs, partitioning, full-text search). | Unassigned | Deployment constraints | Not Started | Document rationale. |
+| Define naming conventions, schemas, and migration tooling. | Unassigned | Engineering standards | Not Started | Update README if tooling selected. |
+| Specify indexing for frequent filters (severity, status, resource type, account, fix availability, timestamps). | Unassigned | Query workload analysis | Not Started | Capture results in table. |
+| Design historical snapshot strategy (append-only tables vs. materialized views). | Unassigned | Ingestion needs | Not Started | Note trade-offs. |
+| Implement reference data seeding and sample datasets for testing. | Unassigned | Sample exports | Not Started | Link dataset locations. |
+| Establish schema change control process (review, migration order, rollback). | Unassigned | Program Ops guidance | Not Started | Align with master tracker change management. |
+| Validate schema with ingestion and reporting integration tests. | Unassigned | Other workstreams | Not Started | Record test outcomes in Update Log. |
+
+## Dependencies
+- Input from Ingestion on normalization requirements.
+- Query patterns from Presentation and Admin workstreams.
+- Compliance considerations from Security & Compliance.
+
+## Acceptance Criteria Checklist
+- [ ] ERD and schema docs published with version history.
+- [ ] Migrations executable via automated pipeline with rollback guidance.
+- [ ] Indexing and partitioning validated against performance benchmarks.
+- [ ] Provenance/audit strategy documented and implemented.
+- [ ] Data retention and backup policies aligned with Deployment & Security plans.
+
+## Update Log
+| Date | Author | Summary |
+| --- | --- | --- |
+

--- a/docs/subtasks/deployment-operations.md
+++ b/docs/subtasks/deployment-operations.md
@@ -1,0 +1,47 @@
+# Workstream Tracker — Deployment & Operations
+
+## Mission
+Deliver containerized deployment assets, environment configuration patterns, scaling guidance, backup/restore processes, and operational runbooks enabling reliable local and cloud deployments (without Kubernetes).
+
+## Current Status
+- **Owner:** Unassigned
+- **Status:** Not Started
+- **Last Update:** _None_
+
+## Milestones & Target Outcomes
+| Milestone | Description | Target Exit Criteria | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Environment Strategy | Define local (Docker Compose) and cloud deployment architecture, including networking and storage. | Architecture diagrams and decision log completed. | Not Started | Confirm hosting targets with stakeholders. |
+| Container Build & CI/CD | Create Dockerfiles, base images, and CI pipelines for backend/frontend/services. | Automated builds and image publishing in place. | Not Started | Coordinate with Presentation & Backend teams. |
+| Configuration & Secrets | Establish environment variable schema, secret injection, and config management process. | Config templates documented; secrets strategy validated. | Not Started | Align with Security workstream. |
+| Scaling & Resilience | Document horizontal scaling approach, failover, monitoring, and disaster recovery. | Runbooks and tests demonstrating scaling scenarios. | Not Started | Include backup/restore drills. |
+| Release Operations | Define release checklist, rollback plan, and operational reporting cadence. | Release runbook approved; metrics dashboard live. | Not Started | Sync with Program Ops for comms. |
+
+## Task Board
+| Task | Owner | Dependencies | Status | Notes/Links |
+| --- | --- | --- | --- | --- |
+| Confirm target cloud environment(s) and hosting constraints (no Kubernetes). | Unassigned | Stakeholder input | Not Started | Update architecture diagrams. |
+| Draft docker-compose topology for local development (frontend, backend, DB, job worker). | Unassigned | Service requirements | Not Started | Ensure volume mounts for uploads/backups. |
+| Author production-ready Dockerfiles with multi-stage builds. | Unassigned | Build tooling | Not Started | Capture image size benchmarks. |
+| Set up CI pipeline for image builds, tagging, and vulnerability scanning. | Unassigned | CI provider | Not Started | Coordinate with Security scanning plan. |
+| Define environment variable schema and secrets management workflow. | Unassigned | Security guidance | Not Started | Document defaults in README. |
+| Plan database backup/restore process and retention schedule. | Unassigned | Data Storage inputs | Not Started | Align with Background Processing backup jobs. |
+| Document logging, monitoring, and alert routing for deployed services. | Unassigned | Observability stack | Not Started | Link to dashboards. |
+| Create release checklist including smoke tests, rollback procedures, and stakeholder notifications. | Unassigned | Program Ops | Not Started | Store checklist in `/docs/runbooks/release.md`. |
+
+## Dependencies
+- Container requirements from Presentation, Ingestion, and Background Processing workstreams.
+- Security policies for secrets and vulnerability management.
+- Program Ops for release cadence and stakeholder communication expectations.
+
+## Acceptance Criteria Checklist
+- [ ] Local development environment reproducible via Docker Compose with docs.
+- [ ] Production Docker images built, scanned, and published with versioning strategy.
+- [ ] Configuration and secrets management documented and validated.
+- [ ] Backup/restore, scaling, and DR procedures tested and runbooks published.
+- [ ] Release process defined with checklists and reporting cadence.
+
+## Update Log
+| Date | Author | Summary |
+| --- | --- | --- |
+

--- a/docs/subtasks/ingestion-pipeline.md
+++ b/docs/subtasks/ingestion-pipeline.md
@@ -1,0 +1,49 @@
+# Workstream Tracker — Ingestion Pipeline
+
+## Mission
+Engineer the end-to-end ingestion flow for AWS Inspector exports, covering upload intake, staging, validation, chronological enforcement, normalization, and progress telemetry to support large (≈100 MB+) batches.
+
+## Current Status
+- **Owner:** Unassigned
+- **Status:** Not Started
+- **Last Update:** _None_
+
+## Milestones & Target Outcomes
+| Milestone | Description | Target Exit Criteria | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Intake Design | Define upload channels (UI/API), payload limits, validation rules, and chronological enforcement strategy. | Architecture diagram and decision log attached here. | Not Started | Coordinate with Security on sanitization requirements. |
+| Staging & Storage Implementation | Build durable staging storage, metadata recording, and duplicate detection. | Staging service deployed locally with automated tests. | Not Started | Ensure idempotent retries documented. |
+| Normalization & Processing | Implement parsers, normalization pipelines, transactional writes, and derived metric computation. | Processing jobs successful against sample datasets with benchmarks logged. | Not Started | Align schema with Data Storage workstream. |
+| Telemetry & Error Handling | Provide progress tracking, retry logic, and failure reporting hooks. | Telemetry endpoints and dashboards operational; error taxonomy documented. | Not Started | Feed metrics to Admin workstream. |
+| Handoff & Documentation | Deliver API/CLI interface specs, runbooks, and onboarding guides. | README and runbook updated; integration tests passing. | Not Started | Link to supporting artefacts below. |
+
+## Task Board
+| Task | Owner | Dependencies | Status | Notes/Links |
+| --- | --- | --- | --- | --- |
+| Confirm upload SLA targets and concurrency expectations with stakeholders. | Unassigned | Program Ops clarifications | Not Started | Record in Update Log once received. |
+| Define file validation schemas (JSON, CSV, other formats). | Unassigned | Sample AWS Inspector exports | Not Started | Version schemas in repo. |
+| Design chronological enforcement using report timestamps and advisory locks. | Unassigned | Data Storage schema decisions | Not Started | Document algorithm in `/docs/architecture/ingestion.md`. |
+| Implement streaming parser for large CSV/JSON payloads. | Unassigned | Parser library selection | Not Started | Capture benchmarks. |
+| Build staging persistence (object storage or filesystem) with cleanup policies. | Unassigned | Deployment constraints | Not Started | Include retention schedule. |
+| Create normalization workers with transactional writes to core tables. | Unassigned | Database schema | Not Started | Coordinate with Background Processing for job queue selection. |
+| Instrument ingestion lifecycle telemetry (queued, processing, completed, failed). | Unassigned | Observability stack | Not Started | Ensure data feeds admin dashboards. |
+| Establish failure handling playbooks and alerting thresholds. | Unassigned | Monitoring tools | Not Started | Share runbook link. |
+| Provide API endpoints for upload submission and status polling. | Unassigned | Presentation/API requirements | Not Started | Document in OpenAPI spec. |
+| Write automated tests covering happy paths, large file benchmarks, and failure scenarios. | Unassigned | Test framework | Not Started | Add performance metrics to Update Log. |
+
+## Dependencies
+- Database schema ownership from Data Storage workstream.
+- Job orchestration decisions from Background Processing workstream.
+- Security requirements for input sanitization and rate limiting.
+
+## Acceptance Criteria Checklist
+- [ ] Upload paths handle ≥100 MB files within agreed SLA (<5 minutes target).
+- [ ] Chronological ordering and duplicate detection rules enforced and documented.
+- [ ] Telemetry surfaces ingestion metrics for Admin dashboards.
+- [ ] Comprehensive runbook covering retries, failures, and rollback procedures.
+- [ ] Integration tests with Presentation Layer and exports validated.
+
+## Update Log
+| Date | Author | Summary |
+| --- | --- | --- |
+

--- a/docs/subtasks/presentation-layer.md
+++ b/docs/subtasks/presentation-layer.md
@@ -1,0 +1,51 @@
+# Workstream Tracker — Presentation Layer
+
+## Mission
+Deliver a responsive, accessible web client and public API endpoints that let operators ingest, analyze, and administer AWS Inspector data. This includes UX flows for uploads, dashboards, explorers, history views, and admin tooling, aligned with the approved stack plan.
+
+## Current Status
+- **Owner:** Unassigned
+- **Status:** Not Started
+- **Last Update:** _None_
+
+## Milestones & Target Outcomes
+| Milestone | Description | Target Exit Criteria | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Discovery & Requirements | Finalize UX requirements, UI inventory, and API contracts with backend leads. | Signed-off UX spec, wireframes, and API dependency list documented here. | Not Started | Pending stakeholder review of UX priorities. |
+| Experience Design | Produce high-fidelity mockups, accessibility plan, and interaction guidelines. | Design artifacts stored in repo or design tool with links captured below. | Not Started | Ensure WCAG 2.1 AA considerations noted. |
+| Implementation | Build React/Vite front-end, integrate with FastAPI endpoints, implement state management and validation. | Feature-complete UI with automated lint/test coverage. | Not Started | Coordinate with backend for feature flags. |
+| QA & Accessibility Verification | Execute functional, usability, and accessibility testing. | Test reports attached; all critical issues resolved. | Not Started | Accessibility gate required before release. |
+| Deployment Readiness | Prepare build pipelines, environment configs, and release notes. | Front-end Docker image published; rollout plan documented. | Not Started | Sync with Deployment workstream. |
+
+## Task Board
+| Task | Owner | Dependencies | Status | Notes/Links |
+| --- | --- | --- | --- | --- |
+| Document user personas and primary workflows across upload, analysis, history, admin. | Unassigned | Program Ops discovery outputs | Not Started | Capture in `/docs/research/personas.md` if needed. |
+| Define API consumption needs (REST/GraphQL endpoints, pagination, auth). | Unassigned | Ingestion & Background Processing API specs | Not Started | Track contract changes in this file. |
+| Draft UX wireframes for each workspace (Upload Manager, Dashboard, Explorer, History, Admin). | Unassigned | Personas/workflows | Not Started | Link exported PDFs or tool share links. |
+| Develop component library with shared styles and accessibility tokens. | Unassigned | Design tokens | Not Started | Align with Security guidelines for theming. |
+| Implement upload workspace with drag-and-drop, validation, and progress state. | Unassigned | Ingestion API availability | Not Started | Coordinate on error codes for display. |
+| Build dashboard visualizations (severity breakdown, remediation status, trends). | Unassigned | Data API endpoints | Not Started | Prefer reusable chart components. |
+| Implement vulnerability explorer filtering, grouping, export triggers. | Unassigned | Background export hooks | Not Started | Ensure query performance guidelines respected. |
+| Create historical timeline view referencing archival snapshots. | Unassigned | Data Storage snapshot endpoints | Not Started | Include comparison diff UI. |
+| Deliver admin console with feature toggles, job monitor, and backup tools. | Unassigned | Admin APIs, Security review | Not Started | Ensure audit log display requirements met. |
+| Establish automated test suites (unit, integration, e2e smoke). | Unassigned | CI setup | Not Started | Document coverage thresholds in README when defined. |
+
+## Dependencies
+- API specifications from Ingestion, Data Storage, Background Processing, and Admin workstreams.
+- Auth decisions from Security & Compliance to finalize front-end auth flows.
+- Deployment configuration (environment variables, CDN strategy) from Deployment & Operations.
+
+## Acceptance Criteria Checklist
+- [ ] UX and accessibility sign-off documented with approvals.
+- [ ] All workspace views implemented with responsive layout and error handling.
+- [ ] Public API documentation published and linked in README.
+- [ ] Automated test coverage and linting integrated into CI.
+- [ ] Front-end Docker image versioned and released with deployment notes.
+
+## Update Log
+Use the table below to capture dated updates for quick handoff visibility.
+
+| Date | Author | Summary |
+| --- | --- | --- |
+

--- a/docs/subtasks/security-compliance.md
+++ b/docs/subtasks/security-compliance.md
@@ -1,0 +1,47 @@
+# Workstream Tracker — Security & Compliance
+
+## Mission
+Define and enforce security, privacy, and compliance controls across ingestion, storage, admin tooling, and deployment, including authentication, secrets management, audit logging, and data handling policies.
+
+## Current Status
+- **Owner:** Unassigned
+- **Status:** Not Started
+- **Last Update:** _None_
+
+## Milestones & Target Outcomes
+| Milestone | Description | Target Exit Criteria | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Requirements Gathering | Identify regulatory obligations, internal policies, and stakeholder expectations. | Compliance checklist documented with owners. | Not Started | Clarify auth expectations from stakeholders. |
+| Security Architecture | Define threat model, authN/Z approach, secrets management, and secure upload strategy. | Architecture decisions recorded and reviewed. | Not Started | Coordinate with all workstreams. |
+| Control Implementation | Implement prioritized controls (input sanitization, secrets handling, RBAC, logging). | Controls tested and integrated across stack. | Not Started | Include automated security tests. |
+| Verification & Audit Prep | Conduct security testing, document evidence, and prepare for audits. | Security report published; issues tracked to resolution. | Not Started | Feed findings into risk log. |
+| Ongoing Governance | Establish review cadence, incident response, and compliance monitoring. | Runbooks and monitoring schedules approved. | Not Started | Align with Program Ops cadence. |
+
+## Task Board
+| Task | Owner | Dependencies | Status | Notes/Links |
+| --- | --- | --- | --- | --- |
+| Resolve clarifying questions (auth scope, export data sensitivity, backup retention). | Unassigned | Stakeholder input | Not Started | Update master risk log when answered. |
+| Draft threat model covering ingestion, storage, admin, exports, and deployment. | Unassigned | Architecture diagrams | Not Started | Store model in `/docs/security/`. |
+| Define authentication and authorization strategy (SSO/basic, API keys). | Unassigned | Stakeholder decision | Not Started | Document fallback options. |
+| Establish secrets management pattern for Docker/local/cloud environments. | Unassigned | Deployment strategy | Not Started | Include rotation procedures. |
+| Specify upload sanitization, validation, and isolation controls. | Unassigned | Ingestion design | Not Started | Document acceptance criteria. |
+| Create audit logging and monitoring requirements across services. | Unassigned | Admin telemetry outputs | Not Started | Map to compliance needs. |
+| Plan security testing (static analysis, dependency scanning, penetration tests). | Unassigned | Tooling availability | Not Started | Integrate with CI pipeline. |
+| Develop incident response plan and escalation matrix. | Unassigned | Program Ops | Not Started | Store runbook in `/docs/runbooks/incident-response.md`. |
+
+## Dependencies
+- Architecture decisions from all engineering workstreams.
+- Program Operations for compliance obligations and stakeholder communications.
+- Deployment workstream for environment-specific constraints.
+
+## Acceptance Criteria Checklist
+- [ ] Threat model and control matrix approved by stakeholders.
+- [ ] Authentication, secrets management, and upload safety controls implemented and tested.
+- [ ] Audit logging and monitoring integrated with Admin surfaces.
+- [ ] Security testing plan executed with remediation tracked to completion.
+- [ ] Incident response and ongoing governance procedures documented.
+
+## Update Log
+| Date | Author | Summary |
+| --- | --- | --- |
+

--- a/stack-plan.md
+++ b/stack-plan.md
@@ -1,0 +1,40 @@
+# Stack Implementation Plan
+
+## Presentation Layer (UI & APIs)
+- **Front-end approach**: Build a responsive, accessibility-conscious web UI with dedicated workspaces for upload management, dashboards, explorers, history, and admin tooling, ensuring it can sit atop REST/GraphQL APIs for automation clients.
+- **Key features**: Drag-and-drop upload workspace with validation feedback; dashboard showcasing severity breakdowns, remediation status, and trends; vulnerability explorer with rich filtering, grouping, and export triggers; historical timeline views; admin console for health and backup operations.
+- **API surface**: Expose endpoints for uploads, filtering queries, historical comparisons, and export requests (including async job polling). Support optional authentication hooks for SSO/basic auth or future API keys.
+
+## Ingestion Pipeline
+- **Upload handling**: Browser and API uploads with chronological ordering by derived report timestamp, duplicate detection, and schema validation, failing fast on invalid files. Stage files in durable storage prior to processing.
+- **Processing**: Transactional normalization into core entities, derived metric computation (severity counts, first/last seen, fix availability), and snapshot archival before replacing live tables. Implement retry/resume mechanics and progress telemetry (polling or websockets).
+- **Scalability**: Ensure ingestion of ~100 MB files within target SLA (<5 min) through streaming parsers for CSV and concurrent-safe orchestration with advisory locks/work queues.
+
+## Data Storage & Modeling
+- **Schema**: Normalize reports, findings, resources, packages, references, upload events, and append-only history tables linking to report IDs and archival timestamps to preserve provenance.
+- **Indexing**: Optimize for frequent filters (severity, status, resource type, account, fix availability, timestamps) and full-text search over titles/descriptions, while supporting pagination defaults around 50 records per page.
+- **Technology**: Use a relational database (e.g., PostgreSQL) with transaction support; plan for migrations, seed data, and historical snapshot management.
+
+## Background Processing & Exports
+- **Job system**: Manage archival moves, export generation (PDF/CSV/Markdown/Notion), backups, and retention policies via queued jobs or scheduled tasks. Async exports should deliver downloadable links upon completion.
+- **Telemetry**: Track ingest lifecycle events (queued → completed/failed) with metrics for durations, file sizes, and queue depth to surface in admin views.
+
+## Admin & Telemetry Surfaces
+- **Admin console**: Provide feature-flagged tools to trigger/view backups, clear/reseed data with confirmations, inspect system health, and audit long-running jobs. Include audit logging for key operations.
+- **Health endpoints**: Implement liveness/readiness probes, environment info, and ingestion telemetry compatible with container orchestrators.
+
+## Security & Compliance
+- **Upload safety**: Sanitize filenames/content, validate schemas, and isolate staging storage. Log ingest outcomes with actor identity.
+- **Secrets management**: Configure via environment variables backed by secure secret storage; avoid hard-coded credentials. Offer optional SSO/basic auth/IP allowlists as deployment context requires.
+
+## Deployment & Operations
+- **Containerization**: Deliver Docker images with environment-based configuration for DB credentials, upload limits, feature toggles, and admin access. Document deployment to Docker/Fly.io/Kubernetes with persistent volumes for uploads/backups.
+- **Scalability & resilience**: Enable horizontal scaling for ingestion/query nodes using locks or work queues to prevent duplication; outline backup/restore procedures capturing schema + data; plan for disaster recovery and monitoring.
+- **Validation**: Test with representative AWS Inspector datasets to confirm performance, historical accuracy, and export fidelity.
+
+## Clarifying Questions
+1. **Tech stack preferences**: Do you have existing tooling or language/framework constraints we should align with (e.g., React vs. Vue, Django vs. Rails)?
+2. **Authentication scope**: Should we plan for built-in auth (SSO/basic) from the outset, or keep it optional behind environment-level protections?
+3. **Export formats priority**: Among PDF, CSV, and Markdown/Notion outputs, are there must-have deliverables for an initial release to guide backlog ordering?
+4. **Backup cadence**: Should scheduled backups and remote retention be part of MVP, or is on-demand via admin console sufficient initially?
+5. **Target ingest volume**: Beyond the cited ~100 MB per file, do you anticipate larger batch uploads or specific concurrency requirements that would influence infrastructure sizing?


### PR DESCRIPTION
## Summary
- add a master build tracker with status legends, coordination rules, and acceptance checklist to orchestrate the program
- create detailed workstream trackers for presentation, ingestion, storage, background jobs, admin surfaces, security, and deployment
- document contributor workflow and onboarding guidance in a new repository README for developers and stakeholders

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d48c0133648326a65190a9d9ee9d3b